### PR TITLE
allow custom protocol by passing it in apiHost

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Really, really simple NodeJS wrapper for the Brandwatch API that wraps [request]
 
 ```javascript
 var BrandwatchAPI = require('brandwatch-api').BrandwatchAPI,
-    api = new BrandwatchAPI({apiHost: 'newapi.brandwatch.com', apiPort: 80}, {
+    api = new BrandwatchAPI({apiUrl: 'http://newapi.brandwatch.com:80'}, {
         auth: access_token
     });
-    
+
 // "api" is a wrapped request object
 api.get('/user', function(err, res, body){
 });

--- a/lib/api.js
+++ b/lib/api.js
@@ -9,7 +9,7 @@ var url = require('url'),
         json: true
     });
 
-function buildRequest(apiHost, apiPort, method, options, requestOptions, callback){
+function buildRequest(apiUrl, apiUrlParts, method, options, requestOptions, callback){
     var uri = options.url || options.uri,
         sendOptions = {};
 
@@ -25,12 +25,19 @@ function buildRequest(apiHost, apiPort, method, options, requestOptions, callbac
     sendOptions = _.defaults(options, requestOptions);
 
     sendOptions.method = (method === 'del' ? 'delete' : method).toUpperCase();
-    sendOptions.uri = url.format({
-        protocol: 'http',
-        hostname: apiHost,
-        port: apiPort,
-        pathname: uri
-    });
+
+    if (apiUrl !== undefined) {
+        sendOptions.uri = url.resolve(apiUrl, uri);
+    } else {
+        console.warn('Deprecated api, use apiUrl instead of apiHost and apiPort');
+        sendOptions.uri = url.format({
+            protocol: 'http',
+            hostname: apiUrlParts.apiHost,
+            port: apiUrlParts.apiPort,
+            pathname: uri
+        });
+    }
+
     delete sendOptions.url;
 
     debug('Making request to brandwatchApi', sendOptions.method, sendOptions.uri, sendOptions.query || {}, sendOptions.auth);
@@ -45,6 +52,7 @@ function buildRequest(apiHost, apiPort, method, options, requestOptions, callbac
 }
 
 function BrandwatchAPI(options, requestOptions){
+    this.apiUrl = options.apiUrl;
     this.apiHost = options.apiHost;
     this.apiPort = options.apiPort;
 
@@ -53,7 +61,8 @@ function BrandwatchAPI(options, requestOptions){
 
 ['get', 'post', 'put', 'patch', 'del'].forEach(function(method){
     BrandwatchAPI.prototype[method] = function(options, callback){
-        return buildRequest(this.apiHost, this.apiPort, method, options, this.requestOptions, callback);
+        var apiUrlParts = { apiHost: this.apiHost, apiPort: this.apiPort };
+        return buildRequest(this.apiUrl, apiUrlParts, method, options, this.requestOptions, callback);
     };
 });
 

--- a/test/api.tests.js
+++ b/test/api.tests.js
@@ -5,105 +5,206 @@ var sinon = require('sinon'),
 
 describe('brandwatchApi', function(){
     var sandbox = sinon.sandbox.create(),
-        requestStartStub,
-        brandwatchApi;
+        requestStartStub;
 
     beforeEach(function(){
         requestStartStub = sandbox.stub(request.Request.prototype, 'init');
-
-        brandwatchApi = new BrandwatchApi({
-            apiHost: 'localhost',
-            apiPort: 9999
-        }, {
-            auth: 'abcdef'
-        });
     });
     afterEach(function(){
         sandbox.restore();
     });
 
-    it('Has get, post, put, patch and del methods', function(){
-        expect(brandwatchApi.get).toBeDefined();
-        expect(brandwatchApi.post).toBeDefined();
-        expect(brandwatchApi.put).toBeDefined();
-        expect(brandwatchApi.patch).toBeDefined();
-        expect(brandwatchApi.del).toBeDefined();
-    });
-    it('passes GET method to request on get', function(done){
-        brandwatchApi.get('/ping');
+    describe('using the old apiHost and apiPort params', function () {
+        var brandwatchApi;
 
-        process.nextTick(function(){
-            expect(requestStartStub.calledOnce).toEqual(true);
-            expect(requestStartStub.thisValues[0].method).toEqual('GET');
+        beforeEach(function(){
+            brandwatchApi = new BrandwatchApi({
+                apiHost: 'localhost',
+                apiPort: 9999
+            }, {
+                auth: 'abcdef'
+            });
+        });
 
-            done();
+        it('Has get, post, put, patch and del methods', function(){
+            expect(brandwatchApi.get).toBeDefined();
+            expect(brandwatchApi.post).toBeDefined();
+            expect(brandwatchApi.put).toBeDefined();
+            expect(brandwatchApi.patch).toBeDefined();
+            expect(brandwatchApi.del).toBeDefined();
+        });
+        it('passes GET method to request on get', function(done){
+            brandwatchApi.get('/ping');
+
+            process.nextTick(function(){
+                expect(requestStartStub.calledOnce).toEqual(true);
+                expect(requestStartStub.thisValues[0].method).toEqual('GET');
+
+                done();
+            });
+        });
+        it('passes POST method to request on post', function(done){
+            brandwatchApi.post('/ping');
+
+            process.nextTick(function(){
+                expect(requestStartStub.calledOnce).toEqual(true);
+                expect(requestStartStub.thisValues[0].method).toEqual('POST');
+
+                done();
+            });
+        });
+        it('passes PUT method to request on put', function(done){
+            brandwatchApi.put('/ping');
+
+            process.nextTick(function(){
+                expect(requestStartStub.calledOnce).toEqual(true);
+                expect(requestStartStub.thisValues[0].method).toEqual('PUT');
+
+                done();
+            });
+        });
+        it('passes PATCH method to request on patch', function(done){
+            brandwatchApi.patch('/ping');
+
+            process.nextTick(function(){
+                expect(requestStartStub.calledOnce).toEqual(true);
+                expect(requestStartStub.thisValues[0].method).toEqual('PATCH');
+
+                done();
+            });
+        });
+        it('passes DELETE method to request on del', function(done){
+            brandwatchApi.del('/ping');
+
+            process.nextTick(function(){
+                expect(requestStartStub.calledOnce).toEqual(true);
+                expect(requestStartStub.thisValues[0].method).toEqual('DELETE');
+
+                done();
+            });
+        });
+        it('builds URL from the apiHost and apiPort passed in at creation', function(done){
+            brandwatchApi.get('/ping');
+
+            process.nextTick(function(){
+                expect(requestStartStub.args[0][0].uri).toEqual('http://localhost:9999/ping');
+
+                done();
+            });
+        });
+        it('sets Authorization header when auth passed in with options', function(done){
+            brandwatchApi.get({url: '/ping', auth: 'Foo'});
+
+            process.nextTick(function(){
+                expect(requestStartStub.args[0][0].headers.Authorization).toEqual('bearer Foo');
+
+                done();
+            });
+        });
+        it('uses auth from requestOptions if none passed in with options', function(done){
+            brandwatchApi.get('/ping');
+
+            process.nextTick(function(){
+                expect(requestStartStub.args[0][0].headers.Authorization).toEqual('bearer abcdef');
+
+                done();
+            });
         });
     });
-    it('passes POST method to request on post', function(done){
-        brandwatchApi.post('/ping');
 
-        process.nextTick(function(){
-            expect(requestStartStub.calledOnce).toEqual(true);
-            expect(requestStartStub.thisValues[0].method).toEqual('POST');
+    describe('using the new aipUrl param', function () {
+        var brandwatchApi;
 
-            done();
+        beforeEach(function(){
+            brandwatchApi = new BrandwatchApi({
+                apiUrl: 'http://localhost:9999'
+            }, {
+                auth: 'abcdef'
+            });
         });
-    });
-    it('passes PUT method to request on put', function(done){
-        brandwatchApi.put('/ping');
-
-        process.nextTick(function(){
-            expect(requestStartStub.calledOnce).toEqual(true);
-            expect(requestStartStub.thisValues[0].method).toEqual('PUT');
-
-            done();
+        it('Has get, post, put, patch and del methods', function(){
+            expect(brandwatchApi.get).toBeDefined();
+            expect(brandwatchApi.post).toBeDefined();
+            expect(brandwatchApi.put).toBeDefined();
+            expect(brandwatchApi.patch).toBeDefined();
+            expect(brandwatchApi.del).toBeDefined();
         });
-    });
-    it('passes PATCH method to request on patch', function(done){
-        brandwatchApi.patch('/ping');
+        it('passes GET method to request on get', function(done){
+            brandwatchApi.get('/ping');
 
-        process.nextTick(function(){
-            expect(requestStartStub.calledOnce).toEqual(true);
-            expect(requestStartStub.thisValues[0].method).toEqual('PATCH');
+            process.nextTick(function(){
+                expect(requestStartStub.calledOnce).toEqual(true);
+                expect(requestStartStub.thisValues[0].method).toEqual('GET');
 
-            done();
+                done();
+            });
         });
-    });
-    it('passes DELETE method to request on del', function(done){
-        brandwatchApi.del('/ping');
+        it('passes POST method to request on post', function(done){
+            brandwatchApi.post('/ping');
 
-        process.nextTick(function(){
-            expect(requestStartStub.calledOnce).toEqual(true);
-            expect(requestStartStub.thisValues[0].method).toEqual('DELETE');
+            process.nextTick(function(){
+                expect(requestStartStub.calledOnce).toEqual(true);
+                expect(requestStartStub.thisValues[0].method).toEqual('POST');
 
-            done();
+                done();
+            });
         });
-    });
-    it('builds URL from the apiHost and apiPort passed in at creation', function(done){
-        brandwatchApi.get('/ping');
+        it('passes PUT method to request on put', function(done){
+            brandwatchApi.put('/ping');
 
-        process.nextTick(function(){
-            expect(requestStartStub.args[0][0].uri).toEqual('http://localhost:9999/ping');
+            process.nextTick(function(){
+                expect(requestStartStub.calledOnce).toEqual(true);
+                expect(requestStartStub.thisValues[0].method).toEqual('PUT');
 
-            done();
+                done();
+            });
         });
-    });
-    it('sets Authorization header when auth passed in with options', function(done){
-        brandwatchApi.get({url: '/ping', auth: 'Foo'});
+        it('passes PATCH method to request on patch', function(done){
+            brandwatchApi.patch('/ping');
 
-        process.nextTick(function(){
-            expect(requestStartStub.args[0][0].headers.Authorization).toEqual('bearer Foo');
+            process.nextTick(function(){
+                expect(requestStartStub.calledOnce).toEqual(true);
+                expect(requestStartStub.thisValues[0].method).toEqual('PATCH');
 
-            done();
+                done();
+            });
         });
-    });
-    it('uses auth from requestOptions if none passed in with options', function(done){
-        brandwatchApi.get('/ping');
+        it('passes DELETE method to request on del', function(done){
+            brandwatchApi.del('/ping');
 
-        process.nextTick(function(){
-            expect(requestStartStub.args[0][0].headers.Authorization).toEqual('bearer abcdef');
+            process.nextTick(function(){
+                expect(requestStartStub.calledOnce).toEqual(true);
+                expect(requestStartStub.thisValues[0].method).toEqual('DELETE');
 
-            done();
+                done();
+            });
+        });
+        it('builds URL from the apiHost and apiPort passed in at creation', function(done){
+            brandwatchApi.get('/ping');
+
+            process.nextTick(function(){
+                expect(requestStartStub.args[0][0].uri).toEqual('http://localhost:9999/ping');
+
+                done();
+            });
+        });
+        it('sets Authorization header when auth passed in with options', function(done){
+            brandwatchApi.get({url: '/ping', auth: 'Foo'});
+
+            process.nextTick(function(){
+                expect(requestStartStub.args[0][0].headers.Authorization).toEqual('bearer Foo');
+
+                done();
+            });
+        });
+        it('uses auth from requestOptions if none passed in with options', function(done){
+            brandwatchApi.get('/ping');
+
+            process.nextTick(function(){
+                expect(requestStartStub.args[0][0].headers.Authorization).toEqual('bearer abcdef');
+
+                done();
+            });
         });
     });
 });


### PR DESCRIPTION
We need the ability to change the protocol that brandwatch-api uses.

To customize the protocol you can pass the full URL as `apiUrl`:
```js
new BrandwatchApi({apiUrl: 'https://localhost:80'}, {
    auth: access_token
});
```

The previous API still works and will default to HTTP requests when there is no protocol:
```js
new BrandwatchApi({apiHost: 'localhost', apiPort: 80}, {
    auth: access_token
});
```